### PR TITLE
Refactor/db/seeding fix

### DIFF
--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Address extends Model
+{
+    //
+}

--- a/app/Models/BodyType.php
+++ b/app/Models/BodyType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class BodyType extends Model
+{
+    //
+}

--- a/database/migrations/2017_04_28_144731_clean_start.php
+++ b/database/migrations/2017_04_28_144731_clean_start.php
@@ -69,7 +69,6 @@ class CleanStart extends Migration
       'user_working_groups',
       'users',
       'working_groups',
-      'sessions',
       'seeder_logs',
       );
     }

--- a/database/migrations/2017_04_28_151956_new_database_schema.php
+++ b/database/migrations/2017_04_28_151956_new_database_schema.php
@@ -28,15 +28,6 @@ class NewDatabaseSchema extends Migration
             $table->timestamps();
         });
 
-        Schema::create('sessions', function (Blueprint $table) {
-            $table->increments('id'); //This used to be string()->unique();
-            $table->integer('user_id')->nullables();
-            $table->string('ip_address', 45)->nullable();
-            $table->text('user_agent')->nullable();
-            $table->text('payload');
-            $table->integer('last_activity');
-        });
-
         Schema::create('countries', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
@@ -299,6 +290,5 @@ class NewDatabaseSchema extends Migration
         Schema::dropIfExists('modules');
         Schema::dropIfExists('roles');
         Schema::dropIfExists('seeder_logs');
-        Schema::dropIfExists('sessions');
     }
 }

--- a/database/migrations/2017_04_28_151956_new_database_schema.php
+++ b/database/migrations/2017_04_28_151956_new_database_schema.php
@@ -190,6 +190,8 @@ class NewDatabaseSchema extends Migration
         Schema::create('roles', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
+            $table->string('code');
+            $table->integer('system_role');
             $table->integer('is_disabled')->nullable();
             $table->timestamps();
         });

--- a/database/seeds/AddSuperAdmin.php
+++ b/database/seeds/AddSuperAdmin.php
@@ -2,7 +2,9 @@
 
 use Illuminate\Database\Seeder;
 
-use App\Models\Antenna;
+use App\Models\Body;
+use App\Models\BodyType;
+use App\Models\Address;
 use App\Models\User;
 
 class AddSuperAdmin extends Seeder
@@ -14,27 +16,39 @@ class AddSuperAdmin extends Seeder
      */
     public function run()
     {
-    	Antenna::create([
-    		'name'			=>	'Global antenna',
-    		'city'			=>	'Cluj-Napoca',
-    		'country_id' 	=>	1
+        Address::create([
+            'id'            =>  1,
+            'country_id'    =>  21,
+            'street'        =>  'Notelaarsstraat 55',
+            'zipcode'       =>  '1000',
+            'city'          =>  'Brussels',
+        ]);
+
+        BodyType::create([
+            'id'            =>  1,
+            'name'          =>  'special',
+        ]);
+
+    	Body::create([
+            'type_id'       =>  1,
+            'address_id'    =>  1,
+    		'name'			=>	'AEGEE-Europe',
+            'email'         =>  'headoffice@aegee.org',
+            'legacy_key'    =>  'AEU'
     	]);
 
         User::create([
-			'contact_email' 	=> 	'flaviu@glitch.ro',
-			'first_name'		=>	'Flaviu',
-			'last_name'			=>	'Porutiu',
-			'date_of_birth'		=>	'1994-01-24',
-			'gender'			=>	1,
-			'antenna_id'		=>	1,
-			'university'		=>	'UBB Cluj',
-			'studies_type_id'	=>	1,
-			'studies_field_id'	=>	1,
+            'id'                =>  1,
+            'address_id'        =>  1,
+			'contact_email' 	=> 	'admin@aegee.org',
+			'first_name'		=>	'Super',
+			'last_name'			=>	'Admin',
+			'date_of_birth'		=>	'1985-04-16',
+			'gender'			=>	0,
 			'password'			=>	Hash::make('1234'),
 			'activated_at'		=>	date('Y-m-d H:i:s'),
 			'is_superadmin'		=>	1,
-            'city'              =>  'Cluj',
-            'seo_url'           =>  'glitch'
+            'seo_url'           =>  'superadmin'
 		]);
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -18,11 +18,11 @@ class DatabaseSeeder extends Seeder
     		'TypeAndFieldOfStudiesSeeder',
     		'ModuleSeeder',
     		'OptionsSeeder',
-    		'EmailTemplateSeeder',
+    	//	'EmailTemplateSeeder',
     		'AddSuperAdmin',
-            'AddRecrutementModuleSeeder',
+        //    'AddRecrutementModuleSeeder',
             'AddAnnouncementsRole',
-            'BodiesPatch'
+        //    'BodiesPatch'
     	);
 
     	$seeders = SeederLog::all();


### PR DESCRIPTION
This fixes the database seeding from running.
3 seeders have been disabled, 1 has been adjusted.

About the BodiesPatch (which is disabled now):
This seemed to migrate existing data. This is not what seeding is for as far as I understand. To my believes seeding should be used on a clean install only, filling the system with either necessary basic data or data used for testing. If the system is already used migrations should take care of data migrations and seeding should not be used when upgrading the system.