### PR TITLE
Update ApiCheckMiddleware.php

### DIFF
--- a/app/Http/Middleware/ApiCheckMiddleware.php
+++ b/app/Http/Middleware/ApiCheckMiddleware.php
@@ -37,7 +37,7 @@ class ApiCheckMiddleware
                         })
                         ->firstOrFail();
         } catch(ModelNotFoundException $ex) {
-            return response()->forbidden();
+            return response()->unauthorized();
         }
 
         Auth::logout(); //Just to be safe, should not be necessary.


### PR DESCRIPTION
Returns 401 in case there is no token or an invalid one. In the future a 403 should be returned in case a request with a valid token does not have enough permissions