### PR TITLE
Reenabled token copying to the shared folder

### DIFF
--- a/docker/omscore/Dockerfile.dev
+++ b/docker/omscore/Dockerfile.dev
@@ -95,5 +95,5 @@ WORKDIR /var/www
 CMD chown -R laradock:laradock /var/www \
     && touch /var/shared/api-key \
     && chown -R laradock:laradock /var/shared \
-    && su - laradock -c 'sh /var/scripts/bootstrap.sh' \
+    && sh /var/scripts/bootstrap.sh \
     && gulp watch # TODO: also run this as laradock

--- a/docker/omscore/bootstrap.sh
+++ b/docker/omscore/bootstrap.sh
@@ -27,9 +27,10 @@ else
 	php artisan config:cache   || { echo "Error at config:cache (3)"; exit 18; }
 
 	# Make omscore write out the api-key
-    echo "Write out API Key:"
+  echo "Write out API Key:"
 	echo "app()->call([app()->make('App\\Http\\Controllers\\ModuleController'), 'getSharedSecret'], [])->original;" | php artisan tinker || { echo "Error at artisan tinker"; exit 17; }
 
+  cp /var/www/storage/key /var/shared/api-key
 
 	# Copy the key into the volume mount so other 
 	mkdir -p /var/shared


### PR DESCRIPTION
This is necessary right now for the registry to register frontend modules to the core.